### PR TITLE
chore: enable Dependabot version updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,21 @@
+version: 2
+updates:
+  - package-ecosystem: "pip"
+    directories:
+      - "/"
+      - "/docs/source-materials/theory"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 3
+    groups:
+      pip-deps:
+        patterns: ["*"]
+  - package-ecosystem: "github-actions"
+    directories:
+      - "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 3
+    groups:
+      github-actions-deps:
+        patterns: ["*"]


### PR DESCRIPTION
Fleet-wide freshness rollout: weekly grouped version updates for all detected ecosystems (pip gha), capped at 3 open PRs per ecosystem. Vulnerability alerts and automated security fixes enabled alongside.

🤖 Generated with [Claude Code](https://claude.com/claude-code)