### PR TITLE
[limen GEN-organvm-auto-revision-epistemic-engine-test-coverage-0620] Raise test coverage in organvm/auto-revision-epistemic-engine

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,8 +1,50 @@
 """Test configuration"""
-import pytest
-import tempfile
-import shutil
+
+import hashlib
 import os
+import shutil
+import sys
+import tempfile
+import types
+from pathlib import Path
+
+import pytest
+
+
+ROOT_DIR = Path(__file__).resolve().parents[1]
+SRC_DIR = ROOT_DIR / "src"
+
+if str(SRC_DIR) not in sys.path:
+    sys.path.insert(0, str(SRC_DIR))
+
+
+try:
+    import blake3  # noqa: F401
+except ModuleNotFoundError:
+    class _Blake3TestHash:
+        """Small hash object matching the subset of blake3 used by tests."""
+
+        def __init__(self, data: bytes = b""):
+            self._hash = hashlib.blake2b(digest_size=32)
+            if data:
+                self.update(data)
+
+        def update(self, data: bytes):
+            self._hash.update(data)
+            return self
+
+        def digest(self, length=None):
+            digest = self._hash.digest()
+            return digest if length is None else digest[:length]
+
+        def hexdigest(self, length=None):
+            digest = self._hash.hexdigest()
+            return digest if length is None else digest[: length * 2]
+
+    def _blake3(data: bytes = b"", **_kwargs):
+        return _Blake3TestHash(data)
+
+    sys.modules["blake3"] = types.SimpleNamespace(blake3=_blake3)
 
 
 @pytest.fixture

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,0 +1,188 @@
+"""Tests for the package command-line entry point."""
+
+import argparse
+import json
+import sys
+
+import auto_revision_epistemic_engine
+from auto_revision_epistemic_engine import __main__ as cli
+
+
+def _last_json_object(output):
+    decoder = json.JSONDecoder()
+    position = 0
+    last = None
+    while position < len(output):
+        while position < len(output) and output[position].isspace():
+            position += 1
+        if position >= len(output):
+            break
+        last, position = decoder.raw_decode(output, position)
+    return last
+
+
+def test_main_without_command_prints_help(monkeypatch, capsys):
+    monkeypatch.setattr(sys, "argv", ["auto-revision-epistemic-engine"])
+
+    assert cli.main() == 0
+
+    captured = capsys.readouterr()
+    assert "Available commands" in captured.out
+    assert "run" in captured.out
+
+
+def test_run_command_parses_inline_inputs(monkeypatch, tmp_path, capsys):
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "auto-revision-epistemic-engine",
+            "run",
+            "--pipeline-id",
+            "cli-inline",
+            "--seed",
+            "321",
+            "--inputs",
+            '{"records": 5, "data": {"kind": "inline"}}',
+            "--no-hrg",
+            "--no-ethics",
+            "--audit-dir",
+            str(tmp_path / "audit"),
+            "--state-dir",
+            str(tmp_path / "state"),
+        ],
+    )
+
+    assert cli.main() == 0
+
+    result = json.loads(capsys.readouterr().out)
+    assert result["success"] is True
+    assert result["pipeline_status"]["pipeline_id"] == "cli-inline"
+    assert "hrg_stats" not in result["pipeline_status"]
+    assert "ethics_compliance" not in result["pipeline_status"]
+
+
+def test_run_command_uses_inputs_file_config(tmp_path, capsys):
+    inputs_file = tmp_path / "pipeline.json"
+    inputs_file.write_text(
+        json.dumps(
+            {
+                "pipeline_id": "file-pipeline",
+                "random_seed": 987,
+                "inputs": {"records": 4},
+                "hrg_config": {"auto_approve": True},
+                "ethics_config": {"enabled": False},
+            }
+        ),
+        encoding="utf-8",
+    )
+    args = argparse.Namespace(
+        inputs=None,
+        inputs_file=str(inputs_file),
+        pipeline_id="ignored",
+        seed=None,
+        no_hrg=True,
+        no_ethics=False,
+        audit_dir=str(tmp_path / "audit"),
+        state_dir=str(tmp_path / "state"),
+    )
+
+    assert cli.cmd_run(args) == 0
+
+    result = json.loads(capsys.readouterr().out)
+    status = result["pipeline_status"]
+    assert status["pipeline_id"] == "file-pipeline"
+    assert status["reproducibility"]["random_seed"] == 987
+    assert status["hrg_stats"]["total_reviews"] == 4
+    assert "ethics_compliance" not in status
+
+
+def test_status_command_reports_initialized_pipeline(monkeypatch, tmp_path, capsys):
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "auto-revision-epistemic-engine",
+            "status",
+            "--pipeline-id",
+            "status-cli",
+            "--seed",
+            "42",
+            "--audit-dir",
+            str(tmp_path / "audit"),
+            "--state-dir",
+            str(tmp_path / "state"),
+        ],
+    )
+
+    assert cli.main() == 0
+
+    status = json.loads(capsys.readouterr().out)
+    assert status["pipeline_id"] == "status-cli"
+    assert status["started"] is False
+    assert status["completed"] is False
+    assert status["phase_status"]["status"] == "NOT_STARTED"
+
+
+def test_audit_command_after_run_verifies_chain(monkeypatch, tmp_path, capsys):
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "auto-revision-epistemic-engine",
+            "audit",
+            "--after-run",
+            "--audit-dir",
+            str(tmp_path / "audit"),
+            "--state-dir",
+            str(tmp_path / "state"),
+        ],
+    )
+
+    assert cli.main() == 0
+
+    captured = capsys.readouterr()
+    audit = json.loads(captured.out)
+    assert audit["chain_valid"] is True
+    assert "[OK] Audit chain integrity verified." in captured.err
+
+
+def test_audit_command_returns_failure_for_invalid_chain(monkeypatch, tmp_path, capsys):
+    class FakeEngine:
+        def __init__(self, **_kwargs):
+            pass
+
+        def execute(self, inputs=None):
+            return {"success": True, "inputs": inputs}
+
+        def get_audit_trail(self):
+            return {"chain_valid": False, "total_entries": 0}
+
+    monkeypatch.setattr(auto_revision_epistemic_engine, "AutoRevisionEngine", FakeEngine)
+    args = argparse.Namespace(
+        pipeline_id=None,
+        after_run=False,
+        audit_dir=str(tmp_path / "audit"),
+        state_dir=str(tmp_path / "state"),
+    )
+
+    assert cli.cmd_audit(args) == 1
+
+    captured = capsys.readouterr()
+    assert json.loads(captured.out)["chain_valid"] is False
+    assert "[FAIL] Audit chain integrity BROKEN." in captured.err
+
+
+def test_demo_command_prints_reports_and_completion(monkeypatch, tmp_path, capsys):
+    demo_dirs = iter([tmp_path / "demo-audit", tmp_path / "demo-state"])
+    monkeypatch.setattr(cli.tempfile, "mkdtemp", lambda prefix: str(next(demo_dirs)))
+
+    assert cli.cmd_demo(argparse.Namespace()) == 0
+
+    output = capsys.readouterr().out
+    assert '"stage": "init"' in output
+    assert '"stage": "reports"' in output
+    final_message = _last_json_object(output)
+    assert final_message["stage"] == "complete"
+    assert final_message["audit_dir"] == str(tmp_path / "demo-audit")
+    assert final_message["state_dir"] == str(tmp_path / "demo-state")

--- a/tests/test_orchestrator.py
+++ b/tests/test_orchestrator.py
@@ -1,0 +1,248 @@
+"""Focused tests for the core orchestrator governance flow."""
+
+from types import SimpleNamespace
+
+import pytest
+
+from auto_revision_epistemic_engine.core.orchestrator import (
+    Orchestrator,
+    PipelineConfig,
+)
+from auto_revision_epistemic_engine.hrg.human_review_gate import ReviewStatus
+from auto_revision_epistemic_engine.phases.phase_manager import (
+    PhaseName,
+    PhaseStatus,
+)
+
+
+def _config(tmp_path, **overrides):
+    defaults = {
+        "pipeline_id": "orchestrator-test",
+        "random_seed": 123,
+        "audit_log_dir": str(tmp_path / "audit"),
+        "state_dir": str(tmp_path / "state"),
+    }
+    defaults.update(overrides)
+    return PipelineConfig(**defaults)
+
+
+def _event_types(orchestrator):
+    return [entry.event_type for entry in orchestrator.audit_logger.get_entries()]
+
+
+def test_pipeline_runs_all_phases_with_governance_artifacts(tmp_path):
+    orchestrator = Orchestrator(_config(tmp_path))
+
+    result = orchestrator.execute_pipeline(
+        {"records": 7, "data": {"source": "unit-test"}}
+    )
+
+    assert result["success"] is True
+    assert result["outputs"]["final_output"] == {"status": "finalized"}
+    assert orchestrator.pipeline_started is True
+    assert orchestrator.pipeline_completed is True
+
+    status = result["pipeline_status"]
+    assert status["phase_status"]["status"] == "COMPLETED"
+    assert status["phase_status"]["phases_completed"] == len(PhaseName)
+    assert status["hrg_stats"]["total_reviews"] == 4
+    assert status["hrg_stats"]["by_status"][ReviewStatus.APPROVED.value] == 4
+    assert status["resource_stats"]["count"] == len(PhaseName) * 2
+    assert status["ethics_compliance"]["total_audits"] == len(PhaseName) * 2
+    assert status["reproducibility"]["snapshots_count"] == len(PhaseName)
+    assert status["audit_chain_valid"] is True
+
+    gate_phases = {
+        PhaseName.INGESTION,
+        PhaseName.PROCESSING,
+        PhaseName.VALIDATION,
+        PhaseName.FINALIZATION,
+    }
+    executions = orchestrator.phase_manager.get_phase_executions()
+    assert all(ex.status == PhaseStatus.COMPLETED for ex in executions)
+    assert {
+        ex.phase for ex in executions if ex.hrg_review_id is not None
+    } == gate_phases
+
+    attestation_types = {
+        att.attestation_type for att in orchestrator.audit_logger.get_attestations()
+    }
+    assert attestation_types == {
+        "RESOURCE_COMPLIANCE",
+        "ETHICS_COMPLIANCE",
+        "REPRODUCIBILITY",
+    }
+    assert "HRG_REVIEW_REQUESTED" in _event_types(orchestrator)
+
+
+def test_disabled_governance_components_leave_only_reproducibility_status(tmp_path):
+    orchestrator = Orchestrator(
+        _config(
+            tmp_path,
+            enable_hrg=False,
+            enable_ethics_audit=False,
+            enable_resource_tracking=False,
+        )
+    )
+
+    result = orchestrator.execute_pipeline({"records": 3})
+    status = result["pipeline_status"]
+
+    assert result["success"] is True
+    assert "hrg_stats" not in status
+    assert "resource_stats" not in status
+    assert "ethics_compliance" not in status
+    assert status["reproducibility"]["snapshots_count"] == len(PhaseName)
+    assert orchestrator.hrg is None
+    assert orchestrator.rol_t is None
+    assert orchestrator.ethics is None
+
+    orchestrator._allocate_phase_resources(PhaseName.INGESTION, "no-op")
+    orchestrator._record_phase_resource_usage(PhaseName.INGESTION, "no-op")
+    orchestrator._simulate_hrg_approval("no-op")
+
+    attestations = orchestrator.audit_logger.get_attestations()
+    assert [att.attestation_type for att in attestations] == ["REPRODUCIBILITY"]
+
+
+def test_execute_pipeline_stops_and_logs_failed_phase(tmp_path, monkeypatch):
+    orchestrator = Orchestrator(
+        _config(
+            tmp_path,
+            enable_hrg=False,
+            enable_ethics_audit=False,
+            enable_resource_tracking=False,
+        )
+    )
+    original_logic = orchestrator._execute_phase_logic
+
+    def fail_processing(phase, inputs):
+        if phase == PhaseName.PROCESSING:
+            raise RuntimeError("processing blew up")
+        return original_logic(phase, inputs)
+
+    monkeypatch.setattr(orchestrator, "_execute_phase_logic", fail_processing)
+
+    result = orchestrator.execute_pipeline({"records": 2})
+
+    assert result == {
+        "success": False,
+        "failed_at_phase": PhaseName.PROCESSING.value,
+        "error": "processing blew up",
+    }
+    assert orchestrator.pipeline_completed is False
+
+    status = orchestrator.get_pipeline_status()["phase_status"]
+    assert status["status"] == "FAILED"
+    assert status["phases_completed"] == 2
+    assert status["status_breakdown"][PhaseStatus.FAILED.value] == 1
+
+    failed = orchestrator.phase_manager.get_phase_executions(
+        phase=PhaseName.PROCESSING,
+        status=PhaseStatus.FAILED,
+    )
+    assert len(failed) == 1
+    assert failed[0].error == "processing blew up"
+    assert "PHASE_FAILED" in _event_types(orchestrator)
+    assert "PIPELINE_FAILED" in _event_types(orchestrator)
+
+
+def test_pre_phase_ethics_violation_blocks_before_snapshot(tmp_path, monkeypatch):
+    orchestrator = Orchestrator(
+        _config(tmp_path, enable_hrg=False, enable_resource_tracking=False)
+    )
+
+    def violating_audit(_phase, _context, _stage):
+        return SimpleNamespace(violations=[{"axiom_id": "ACCT_001"}])
+
+    monkeypatch.setattr(orchestrator, "_conduct_ethics_audit", violating_audit)
+
+    result = orchestrator._execute_phase(PhaseName.INGESTION, {})
+
+    assert result == {
+        "success": False,
+        "error": "Ethics violation (PRE): ACCT_001",
+    }
+    executions = orchestrator.phase_manager.get_phase_executions()
+    assert len(executions) == 1
+    assert executions[0].status == PhaseStatus.FAILED
+    assert executions[0].outputs == {}
+    assert orchestrator.state_manager.get_reproducibility_info()["snapshots_count"] == 0
+    assert "ETHICS_VIOLATION" in _event_types(orchestrator)
+
+
+def test_post_phase_ethics_violation_fails_after_snapshot(tmp_path, monkeypatch):
+    orchestrator = Orchestrator(
+        _config(tmp_path, enable_hrg=False, enable_resource_tracking=False)
+    )
+
+    def staged_audit(_phase, _context, stage):
+        violations = [{"axiom_id": "SAFE_001"}] if stage == "POST_PHASE" else []
+        return SimpleNamespace(violations=violations)
+
+    monkeypatch.setattr(orchestrator, "_conduct_ethics_audit", staged_audit)
+
+    result = orchestrator._execute_phase(PhaseName.ANALYSIS, {"data": {"x": 1}})
+
+    assert result == {
+        "success": False,
+        "error": "Ethics violation (POST): SAFE_001",
+    }
+    executions = orchestrator.phase_manager.get_phase_executions()
+    assert len(executions) == 1
+    assert executions[0].status == PhaseStatus.FAILED
+    assert executions[0].outputs["analysis_results"] == {"status": "analyzed"}
+    assert orchestrator.state_manager.get_reproducibility_info()["snapshots_count"] == 1
+    assert "ETHICS_VIOLATION" in _event_types(orchestrator)
+
+
+@pytest.mark.parametrize(
+    ("phase", "inputs", "expected"),
+    [
+        (PhaseName.INGESTION, {"records": 11}, {"ingested_records": 11}),
+        (
+            PhaseName.PREPROCESSING,
+            {"ingested_records": 11},
+            {"preprocessed_records": 11},
+        ),
+        (
+            PhaseName.PROCESSING,
+            {"preprocessed_records": 11},
+            {"processed_records": 11},
+        ),
+        (
+            PhaseName.ANALYSIS,
+            {},
+            {"analysis_results": {"status": "analyzed"}},
+        ),
+        (PhaseName.VALIDATION, {}, {"validation_passed": True}),
+        (
+            PhaseName.SYNTHESIS,
+            {},
+            {"synthesized_output": {"status": "synthesized"}},
+        ),
+        (PhaseName.REVIEW, {}, {"review_status": "reviewed"}),
+        (
+            PhaseName.FINALIZATION,
+            {},
+            {"final_output": {"status": "finalized"}},
+        ),
+    ],
+)
+def test_phase_logic_emits_phase_specific_outputs(tmp_path, phase, inputs, expected):
+    orchestrator = Orchestrator(
+        _config(
+            tmp_path,
+            enable_hrg=False,
+            enable_ethics_audit=False,
+            enable_resource_tracking=False,
+        )
+    )
+
+    outputs = orchestrator._execute_phase_logic(phase, inputs)
+
+    assert outputs["phase"] == phase.value
+    assert outputs["processed"] is True
+    assert outputs["data"] == inputs.get("data", {})
+    for key, value in expected.items():
+        assert outputs[key] == value


### PR DESCRIPTION
Autonomous **limen** dispatch of task `GEN-organvm-auto-revision-epistemic-engine-test-coverage-0620`.

Find the largest source module in organvm/auto-revision-epistemic-engine with little or no test coverage and add a focused, PASSING test suite for it. Run the repo's own test command and confirm green. No placeholder tests. [auto-generated 2026-06-20 to keep the stream endless]

_Produced in an isolated worktree off origin — review before merge._