### PR TITLE
fix(stale): never auto-close — label only (days-before-close: -1)

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -15,7 +15,7 @@ jobs:
           stale-issue-message: 'Marked stale due to inactivity. Will close in 14 days.'
           stale-pr-message: 'Marked stale due to inactivity. Will close in 14 days.'
           days-before-stale: 60
-          days-before-close: 14
+          days-before-close: -1
           exempt-issue-labels: 'pinned,evergreen,omega,blocked'
           exempt-pr-labels: 'pinned,evergreen,work-in-progress'
           stale-issue-label: 'stale'


### PR DESCRIPTION
The stale workflow auto-closed issues/PRs, violating this universe's absolute doctrine: **we never close, dismiss, or delete** — *if it was ever asked for it was wanted*.

This sets the close window to `-1` (`actions/stale` never-close), preserving the informational `stale` label but never closing. Surgical, reversible, single-file.